### PR TITLE
ref: Add navigation exit/enter sounds

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Geist_Mono } from "next/font/google";
 import { ViewTransition } from "react";
 import "./globals.css";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { NavSoundTrigger } from "@/lib/sound/trigger";
 
 const serif_to_sans = localFont({
 	src: "./fonts/ABCArizona-FlareRegular.otf",
@@ -84,6 +85,7 @@ export default function RootLayout({
 						</main>
 					</div>
 				</TooltipProvider>
+				<NavSoundTrigger />
 				<KeyboardShortcuts />
 				<Analytics />
 			</body>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,9 +1,9 @@
 import SvgIcon from "@/components/common/logo";
+import { NavLink } from "@/components/nav-link";
 import { Badge } from "@/components/ui/badge";
 import { getCompanyLogoSrc } from "@/lib/utils";
 import { promises as fs } from "fs";
 import { Metadata } from "next";
-import Link from "next/link";
 import path from "path";
 
 export const metadata: Metadata = {
@@ -37,10 +37,9 @@ export function ProjectListItem({
 
 	return (
 		<li className="font-medium my-4">
-			<Link
+			<NavLink
 				href={`/projects/${slug}`}
 				className="group flex items-start -mx-2 px-2 focus-visible:outline focus-visible:outline-ring focus-visible:rounded-xs focus-visible:outline-dotted"
-				draggable={false}
 			>
 				<div className="flex flex-col gap-2 min-w-0 flex-1">
 					<div className="flex items-center gap-2">
@@ -73,7 +72,7 @@ export function ProjectListItem({
 						</div>
 					)}
 				</div>
-			</Link>
+			</NavLink>
 		</li>
 	);
 }

--- a/app/writings/page.tsx
+++ b/app/writings/page.tsx
@@ -1,6 +1,6 @@
+import { NavLink } from "@/components/nav-link";
 import { promises as fs } from "fs";
 import { Metadata } from "next";
-import Link from "next/link";
 import path from "path";
 
 export const metadata: Metadata = {
@@ -41,9 +41,8 @@ export default async function Page() {
 			<ul className="flex flex-col gap-y-8 [&>*:first-child]:mt-0 mt-0">
 				{items.map((item) => (
 					<li key={item.slug} className="font-medium">
-						<Link
+						<NavLink
 							href={`/writings/${item.slug}`}
-							draggable={false}
 							className="flex flex-col items-start gap-2"
 						>
 							<div className="flex flex-row w-full justify-between focus-visible:outline focus-visible:outline-ring focus-visible:rounded-xs focus-visible:outline-dotted">
@@ -60,7 +59,7 @@ export default async function Page() {
 									{item.description}
 								</p>
 							)}
-						</Link>
+						</NavLink>
 					</li>
 				))}
 			</ul>

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "sharp": "^0.34.5",
         "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
+        "tone": "^15.1.22",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
@@ -365,6 +366,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
+    "automation-events": ["automation-events@7.1.19", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1" } }, "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA=="],
 
     "autoprefixer": ["autoprefixer@10.4.27", "", { "dependencies": { "browserslist": "^4.28.1", "caniuse-lite": "^1.0.30001774", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA=="],
 
@@ -844,6 +847,8 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "standardized-audio-context": ["standardized-audio-context@25.3.77", "", { "dependencies": { "@babel/runtime": "^7.25.6", "automation-events": "^7.0.9", "tslib": "^2.7.0" } }, "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
@@ -865,6 +870,8 @@
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
+    "tone": ["tone@15.1.22", "", { "dependencies": { "standardized-audio-context": "^25.3.70", "tslib": "^2.3.1" } }, "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -957,6 +964,8 @@
     "@tailwindcss/postcss/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@tailwindcss/postcss/tailwindcss": ["tailwindcss@4.2.0", "", {}, "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q=="],
+
+    "automation-events/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.9.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg=="],
 

--- a/components/keyboard-shortcuts.tsx
+++ b/components/keyboard-shortcuts.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import { playNavExit } from "@/lib/sound";
 
 type ShortcutMap = Record<string, string>;
 
@@ -36,6 +37,7 @@ export function useKeyboardNavigation(shortcuts: ShortcutMap) {
 			if (!route) return;
 
 			e.preventDefault();
+			playNavExit();
 			router.push(route);
 		};
 

--- a/components/nav-link.tsx
+++ b/components/nav-link.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import Link, { type LinkProps } from "next/link";
+import { playNavExit } from "@/lib/sound";
+
+/**
+ * Wraps Next.js Link to provide navigation exit sound feedback.
+ *
+ * A thin wrapper around Next.js `Link` that fires `playNavExit()` in the
+ * onClick handler before navigation proceeds. Use this in your navigation
+ * component instead of a plain `<Link>` to enable the full sound arc:
+ * exit sound → crossfade → enter sound.
+ *
+ * @example
+ * ```tsx
+ * // In your Navbar component
+ * import { NavLink } from "@/components/nav-link"
+ *
+ * <NavLink href="/projects">Projects</NavLink>
+ * <NavLink href="/about">About</NavLink>
+ * ```
+ *
+ * @param props - Standard LinkProps plus children and optional className
+ * @returns Link component with exit sound pre-loaded
+ */
+export function NavLink({
+	children,
+	onClick,
+	...props
+}: LinkProps & React.PropsWithChildren<{ className?: string }>) {
+	/**
+	 * @param children - React nodes to render as link content
+	 * @param onClick - Optional click handler, called after exit sound fires
+	 */
+	return (
+		<Link
+			{...props}
+			onClick={(e) => {
+				playNavExit();
+				onClick?.(e);
+			}}
+		>
+			{children}
+		</Link>
+	);
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 import { Kbd } from "./ui/kbd";
+import { NavLink } from "./nav-link";
 
 const NAV_ITEMS = [
 	{ href: "/", label: "About", key: "A" },
@@ -35,11 +36,10 @@ function Item(props: React.ComponentProps<typeof Link>) {
 				props.className)
 			}
 		>
-			<Link
+			<NavLink
 				{...props}
 				className="inline-block lowercase w-full px-2 focus-visible:outline focus-visible:outline-ring
                     focus-visible:rounded-xs focus-visible:outline-dotted"
-				draggable={false}
 			/>
 		</li>
 	);

--- a/components/timeline/timeline.tsx
+++ b/components/timeline/timeline.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/date";
 import { useIsMobile } from "@/hooks/use-mobile";
 import React, { useMemo } from "react";
+import { NavLink } from "../nav-link";
 
 /* ---------------------------------------------
  * Config
@@ -278,8 +278,8 @@ function TimelineImage({
 	if (!slug) return cardContent;
 
 	return (
-		<Link href={`/timeline/${slug}`} className="block">
+		<NavLink href={`/timeline/${slug}`} className="block">
 			{cardContent}
-		</Link>
+		</NavLink>
 	);
 }

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -1,0 +1,135 @@
+# Navigation Sounds
+
+Crossfade navigation sound system using Tone.js — provides exit/enter audio feedback that complements React's ViewTransition API.
+
+## Installation
+
+Ensure `tone` is installed:
+
+```bash
+bun add tone
+```
+
+## Architecture
+
+```
+@/lib/sound/
+├── index.ts       # Core playback functions (playNavEnter, playNavExit)
+├── trigger.ts    # NavSoundTrigger component for enter sounds
+```
+
+### Two-Sound Arc
+
+Navigation in Next.js App Router doesn't expose a "before navigate" hook, so this system splits the responsibility:
+
+1. **Exit sound** — fired manually in each `<Link>` via `NavLink` component
+2. **Enter sound** — fired automatically by `NavSoundTrigger` on route change
+
+## Usage
+
+### 1. Add NavSoundTrigger to Layout
+
+Place once in your root layout (below `<TooltipProvider>` is fine):
+
+```tsx
+// app/layout.tsx
+import { NavSoundTrigger } from "@/lib/sound/trigger"
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <TooltipProvider>
+          <NavSoundTrigger />
+          {children}
+        </TooltipProvider>
+      </body>
+    </html>
+  )
+}
+```
+
+### 2. Use NavLink Instead of Link
+
+Wrap navigation links in `NavLink` to fire exit sounds before navigation:
+
+```tsx
+// components/navbar.tsx
+import { NavLink } from "@/components/nav-link"
+
+export function Navbar() {
+  return (
+    <nav>
+      <NavLink href="/">Home</NavLink>
+      <NavLink href="/projects">Projects</NavLink>
+      <NavLink href="/about">About</NavLink>
+    </nav>
+  )
+}
+```
+
+### 3. Alternative: Manual Exit Sound
+
+If you can't use `NavLink`, call `playNavExit()` directly in your Link's onClick:
+
+```tsx
+import Link from "next/link"
+import { playNavExit } from "@/lib/sound"
+
+<Link href="/projects" onClick={() => playNavExit()}>
+  Projects
+</Link>
+```
+
+## API Reference
+
+### playNavEnter()
+
+Plays an ascending tonal step (D4 → G4) layered with an arpeggiated chord bloom (C4 → E4 → G4). Designed to complement the crossfade transition — the chord's 2.2s release creates an ambient tail that outlasts the visual transition.
+
+```ts
+await playNavEnter()
+```
+
+### playNavExit()
+
+Plays a descending tonal step (G4 → D4) with a reversed chord bloom. Slightly quieter and shorter than the enter sound to avoid competing with it (~300ms later).
+
+```ts
+playNavExit() // fire and forget (async, but no need to await)
+```
+
+### NavSoundTrigger
+
+Headless component that watches `pathname` and fires `playNavEnter()` on route changes. Skips the initial page load — only fires for actual navigations.
+
+```tsx
+<NavSoundTrigger />
+```
+
+### NavLink
+
+Wrapper around Next.js Link that fires `playNavExit()` in onClick before navigation. Equivalent to:
+
+```tsx
+<Link href="/path" onClick={() => playNavExit()}>
+  Label
+</Link>
+```
+
+### disposeNavSounds()
+
+Cleans up all Tone.js nodes. Call in dev HMR cleanup if needed:
+
+```ts
+if (process.env.NODE_ENV === "development") {
+  disposeNavSounds()
+}
+```
+
+## Design Notes
+
+- **Audio character**: Soft, spatial, ambient — not attention-grabbing. Uses sine oscillators with a long-release reverb tail.
+- **Timing**: The exit sound plays immediately on click; ~300ms later the crossfade begins; once the new page renders, the enter sound fires. This creates a continuous sonic arc across the visual transition.
+- **Browser autoplay**: Tone.js requires user interaction before playing audio. The first link click will initialize the audio context implicitly.
+- **Server-side rendering**: All functions check `typeof window` and no-op on the server — safe to use in SSR contexts.

--- a/lib/sound/index.ts
+++ b/lib/sound/index.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import * as Tone from "tone";
+
+/**
+ * Navigation Sound System
+ *
+ * Provides exit/enter audio feedback for page transitions using Tone.js.
+ * Designed to complement React's ViewTransition API with a crossfade effect.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Reverb effect node for spatial navigation audio.
+ * Initialized lazily on first sound playback.
+ *
+ * @internal
+ */
+let reverb: Tone.Reverb | null = null;
+
+/**
+ * Master volume node controlling overall output level.
+ * Initialized lazily on first sound playback.
+ *
+ * @internal
+ */
+let vol: Tone.Volume | null = null;
+
+/**
+ * Polyphonic synthesizer for playing navigation tones.
+ * Initialized lazily on first sound playback.
+ *
+ * @internal
+ */
+let synth: Tone.PolySynth | null = null;
+
+/**
+ * Tracks whether the audio context and synth nodes have been initialized.
+ *
+ * @internal
+ */
+let initialized = false;
+
+/**
+ * Initializes the Tone.js audio context and creates shared effect nodes.
+ *
+ * Must be called before any playback to ensure the AudioContext is started
+ * (required by browser autoplay policies). Creates a reverb with 3.5s decay
+ * and a polyphonic synth with sine oscillators.
+ *
+ * @internal
+ *
+ * @returns Promise resolving to true if initialization succeeded, false if server-side
+ */
+async function ensureReady(): Promise<boolean> {
+	if (typeof window === "undefined") return false;
+	await Tone.start();
+
+	if (!initialized) {
+		vol = new Tone.Volume(-10).toDestination();
+		reverb = new Tone.Reverb({ decay: 3.5, wet: 0.48 }).connect(vol);
+		synth = new Tone.PolySynth(Tone.Synth, {
+			oscillator: { type: "sine" },
+			envelope: { attack: 0.012, decay: 0.35, sustain: 0.06, release: 2.2 },
+		} as Tone.SynthOptions).connect(reverb);
+		// Reverb needs a moment to generate its IR
+		await reverb.generate();
+		initialized = true;
+	}
+
+	return true;
+}
+
+/**
+ * Plays the navigation enter sound: an ascending tonal step paired with
+ * a layered ripple chord bloom.
+ *
+ * The ascending step (D4 → G4) provides immediate directional feedback,
+ * while the arpeggiated chord (C4 → E4 → G4) creates an ambient tail that
+ * outlasts the crossfade transition. This combination produces a spacious,
+ * spatial quality that complements view transitions.
+ *
+ * @example
+ * ```ts
+ * // Called when a page transition completes (after crossfade)
+ * await playNavEnter()
+ * ```
+ *
+ * @returns Promise that resolves when playback finishes
+ */
+export async function playNavEnter(): Promise<void> {
+	if (!(await ensureReady())) return;
+
+	const now = Tone.now();
+
+	// Tonal step — ascending
+	synth!.triggerAttackRelease("D4", "16n", now, 0.38);
+	synth!.triggerAttackRelease("G4", "16n", now + 0.09, 0.32);
+
+	// Ripple chord bloom (55 ms between voices)
+	synth!.triggerAttackRelease("C4", "8n", now + 0.04, 0.22);
+	synth!.triggerAttackRelease("E4", "8n", now + 0.095, 0.16);
+	synth!.triggerAttackRelease("G4", "8n", now + 0.15, 0.12);
+}
+
+/**
+ * Plays the navigation exit sound: a descending tonal step paired with
+ * a reversed ripple chord bloom.
+ *
+ * Mirror of playNavEnter in reverse — the descending step (G4 → D4) and
+ * reversed chord (G4 → E4 → C4) signal the departure from the current view.
+ * Played at slightly lower volume and with shorter release to avoid competing
+ * with the enter sound that fires ~300ms later during a crossfade.
+ *
+ * @example
+ * ```ts
+ * // Called in NavLink onClick before navigation
+ * playNavExit()
+ * ```
+ *
+ * @returns Promise that resolves when playback finishes
+ */
+export async function playNavExit(): Promise<void> {
+	if (!(await ensureReady())) return;
+
+	const now = Tone.now();
+
+	// Tonal step — descending
+	synth!.triggerAttackRelease("G4", "16n", now, 0.3);
+	synth!.triggerAttackRelease("D4", "16n", now + 0.09, 0.24);
+
+	// Ripple chord bloom (reversed)
+	synth!.triggerAttackRelease("G4", "8n", now + 0.04, 0.16);
+	synth!.triggerAttackRelease("E4", "8n", now + 0.095, 0.12);
+	synth!.triggerAttackRelease("C4", "8n", now + 0.15, 0.09);
+}
+
+/**
+ * Disposes all audio nodes and effect chain.
+ *
+ * Cleans up the synth, reverb, and volume nodes to free memory.
+ * Call this during development HMR cleanup or when unmounting the sound system.
+ *
+ * @example
+ * ```ts
+ * // In dev HMR cleanup
+ * if (process.env.NODE_ENV === "development") {
+ *   disposeNavSounds()
+ * }
+ * ```
+ */
+export function disposeNavSounds(): void {
+	synth?.dispose();
+	synth = null;
+	reverb?.dispose();
+	reverb = null;
+	vol?.dispose();
+	vol = null;
+	initialized = false;
+}

--- a/lib/sound/trigger.ts
+++ b/lib/sound/trigger.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { playNavEnter } from "@/lib/sound/";
+
+/**
+ * Triggers navigation enter sound on route changes.
+ *
+ * A headless component that watches the current pathname and fires
+ * `playNavEnter()` whenever the route changes (excluding initial page load).
+ * Place this component anywhere in your RootLayout — below `<TooltipProvider>`
+ * is a good location.
+ *
+ * Note: Exit sounds require more coordination since Next.js App Router
+ * doesn't expose a "before navigate" hook to layout components. Two approaches:
+ *
+ * **Option A (simple)**: Use only `NavSoundTrigger` — the enter sound alone
+ * provides sufficient audio feedback without needing to wrap every Link.
+ *
+ * **Option B (full)**: Wrap your Link components in a custom component that
+ * calls `playNavExit()` in onClick before `router.push()`. See `NavLink.tsx`
+ * for an example implementation.
+ *
+ * @example
+ * ```tsx
+ * // In app/layout.tsx
+ * <TooltipProvider>
+ *   <NavSoundTrigger />
+ *   {children}
+ * </TooltipProvider>
+ * ```
+ *
+ * @returns null (renders nothing)
+ */
+export function NavSoundTrigger() {
+	const pathname = usePathname();
+	const isFirst = useRef(true);
+
+	useEffect(() => {
+		// Skip the very first render (page load) — no transition has happened.
+		if (isFirst.current) {
+			isFirst.current = false;
+			return;
+		}
+		playNavEnter();
+	}, [pathname]);
+
+	return null;
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"remark-gfm": "^4.0.1",
 		"sharp": "^0.34.5",
 		"shiki": "^4.0.2",
-		"tailwind-merge": "^3.5.0"
+		"tailwind-merge": "^3.5.0",
+		"tone": "^15.1.22"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.13",


### PR DESCRIPTION
## Summary

- Adds Tone.js-based navigation sound system for crossfade transitions
- New `@/lib/sound` module with `playNavEnter()` and `playNavExit()` 
- `NavLink` component wraps Next.js Link for exit sound on click
- `NavSoundTrigger` component fires enter sound on route change
- Documentation added in `docs/sounds.md`