### PR TITLE
fix: highlight about link when navigating to root path

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -21,10 +21,13 @@ function Item(props: React.ComponentProps<typeof Link>) {
 		throw new Error("`href` must be a string");
 	}
 
-	const isActive =
-		href === "/"
-			? pathname === "/"
-			: pathname === href || pathname.startsWith(`${href}/`);
+	const normalizedPathname = pathname ?? "/";
+	let isActive: boolean;
+	if (href === "/") {
+		isActive = normalizedPathname === "/";
+	} else {
+		isActive = normalizedPathname.startsWith(href);
+	}
 	return (
 		<li
 			className={cn(


### PR DESCRIPTION
## Summary
- Fix NavLink highlight issue where the About link wasn't highlighted on the home page
- Handle usePathname() returning null during SSR/hydration by normalizing to /
- Simplify active path matching logic